### PR TITLE
Handle array value from quixel

### DIFF
--- a/RhinoBridge/RhinoBridge.csproj
+++ b/RhinoBridge/RhinoBridge.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RhinoBridge</RootNamespace>
     <AssemblyName>RhinoBridge</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />

--- a/bridge-c-sharp-plugin/App.config
+++ b/bridge-c-sharp-plugin/App.config
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/bridge-c-sharp-plugin/BridgeImporter.cs
+++ b/bridge-c-sharp-plugin/BridgeImporter.cs
@@ -205,7 +205,11 @@ namespace bridge_c_sharp_plugin
             {
                 MetaElement mElement = new MetaElement();
                 mElement.name = (string)obj["name"];
-                mElement.value = (string)obj["value"];
+                if (obj["value"].Type == JTokenType.String) {
+                    mElement.value = (string)obj["value"];
+                } else {
+                    mElement.value = "N/A"; // handling array exception
+                }
                 mElement.key = (string)obj["key"];
 
                 asset.meta.Add(mElement);

--- a/bridge-c-sharp-plugin/bridge-c-sharp-plugin.csproj
+++ b/bridge-c-sharp-plugin/bridge-c-sharp-plugin.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>bridge_c_sharp_plugin</RootNamespace>
     <AssemblyName>bridge-c-sharp-plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/bridge-c-sharp-plugin/obj/Debug/bridge-c-sharp-plugin.csproj.FileListAbsolute.txt
+++ b/bridge-c-sharp-plugin/obj/Debug/bridge-c-sharp-plugin.csproj.FileListAbsolute.txt
@@ -33,3 +33,10 @@ D:\Git\Bridge-C-Sharp-Plugin\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plug
 D:\Git\Bridge-C-Sharp-Plugin\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.csproj.CopyComplete
 D:\Git\Bridge-C-Sharp-Plugin\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.dll
 D:\Git\Bridge-C-Sharp-Plugin\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.pdb
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\bin\Debug\bridge-c-sharp-plugin.dll.config
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\bin\Debug\bridge-c-sharp-plugin.dll
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\bin\Debug\bridge-c-sharp-plugin.pdb
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.csproj.CoreCompileInputs.cache
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.csproj.CopyComplete
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.dll
+C:\Users\iam\Development\misc\RhinoBridge\bridge-c-sharp-plugin\obj\Debug\bridge-c-sharp-plugin.pdb


### PR DESCRIPTION
Make it compile-able for rhino 7 and also handling the exception happening when the value from quixel (specifically `tiling_directions`) is array.

