### PR TITLE
Fix crashing error in Quixel bridge importer.

### DIFF
--- a/RhinoBridge/DataAccess/DataAccessBase.cs
+++ b/RhinoBridge/DataAccess/DataAccessBase.cs
@@ -32,7 +32,7 @@ namespace RhinoBridge.DataAccess
         /// <returns></returns>
         internal RhinoObject GetObjectFromId(Guid id)
         {
-            return new ObjRef(id).Object();
+            return new ObjRef(_doc, id).Object();
         }
     }
 }

--- a/RhinoBridge/DataAccess/MaterialData.cs
+++ b/RhinoBridge/DataAccess/MaterialData.cs
@@ -59,7 +59,7 @@ namespace RhinoBridge.DataAccess
             var id = _doc.Objects.AddSphere(sphere);
 
             // get sphere object
-            var sphereObject = new ObjRef(id).Object();
+            var sphereObject = new ObjRef(_doc, id).Object();
 
             // assign material
             sphereObject.Attributes.MaterialSource = ObjectMaterialSource.MaterialFromObject;

--- a/RhinoBridge/Factories/RenderContentFactory.cs
+++ b/RhinoBridge/Factories/RenderContentFactory.cs
@@ -20,30 +20,9 @@ namespace RhinoBridge.Factories
         /// <returns></returns>
         public static RenderMaterial CreateMaterial(Asset asset, RhinoDoc doc)
         {
-            // create empty material, to fill with asset textures
-            var pbr = CreateEmptyMaterial();
-
-            // set name
-            pbr.Name = $"{asset.name}-{asset.id}";
-
-            // iterate over textures
-            foreach (var texture in asset.textures)
-            {
-                // get texture information
-                var information = texture.ToTextureInformation();
-
-                // create render texture from it
-                var renderTexture = information
-                    .ToSimulatedTexture()
-                    .ToRenderTexture(doc);
-
-                // add render texture as a child
-                pbr.SetChild(renderTexture, information.ChildSlotName);
-                pbr.SetChildSlotOn(information.ChildSlotName, true, RenderContent.ChangeContexts.Ignore);
-            }
-
-            // return material
-            return pbr;
+            // Call scale constructor with meaningless unitsystem,
+            // this basically generates a material that is unscaled
+            return CreateMaterial(asset, doc, doc.ModelUnitSystem);
         }
 
         /// <summary>
@@ -56,9 +35,14 @@ namespace RhinoBridge.Factories
         /// <returns></returns>
         public static RenderMaterial CreateMaterial(Asset asset, RhinoDoc doc, UnitSystem unitSystem)
         {
+            // TODO: asset has a 'meta' property which contains scan Area in meters and height (displacement) in meters
+            // From that info we should be able to generate nicely scaled assets.
+            // We just have to watch out for 3d assets here, as their material has to be differently scaled.
+            // So maybe there are two constructors?
+
             // calculate displacement amount
-            //var displacementAmount = RhinoMath.UnitScale(unitSystem, doc.ModelUnitSystem);
-            var displacementAmount = 1.0;
+            var displacementAmount = RhinoMath.UnitScale(unitSystem, doc.ModelUnitSystem) * 0.01;
+            //var displacementAmount = 1.0;
 
             // create empty material, to fill with asset textures
             var pbr = CreateEmptyMaterial();

--- a/RhinoBridge/Properties/AssemblyInfo.cs
+++ b/RhinoBridge/Properties/AssemblyInfo.cs
@@ -57,8 +57,8 @@ url: https://github.com/DerLando/RhinoBridge")]
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.2.1")]
+[assembly: AssemblyVersion("0.2.2")]
 [assembly: AssemblyFileVersion("1.0.0")]
 
 // Make compatible with Rhino Installer Engine
-[assembly: AssemblyInformationalVersion("0.2.1")]
+[assembly: AssemblyInformationalVersion("0.2.2")]

--- a/RhinoBridge/RhinoBridge.csproj
+++ b/RhinoBridge/RhinoBridge.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RhinoBridge</RootNamespace>
     <AssemblyName>RhinoBridge</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="RhinoCommon">
-      <HintPath>C:\Program Files\Rhino WIP\System\RhinoCommon.dll</HintPath>
+      <HintPath>C:\Program Files\Rhino 7\System\RhinoCommon.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />

--- a/RhinoBridge/RhinoBridgePlugIn.cs
+++ b/RhinoBridge/RhinoBridgePlugIn.cs
@@ -243,7 +243,14 @@ namespace RhinoBridge
                         return;
                     }
 
-                    throw;
+                    else
+                    {
+                        RhinoApp.WriteLine($"An unexpected error occured while trying to import latest asset!");
+                        RhinoApp.WriteLine(ex.Message);
+                    }
+
+                    // TODO: Disabled for now, so application should never crash on the user
+                    //throw;
                 }
 
                 // set machine back to null, so next thread can start working

--- a/bridge-c-sharp-plugin/BridgeImporter.cs
+++ b/bridge-c-sharp-plugin/BridgeImporter.cs
@@ -205,7 +205,7 @@ namespace bridge_c_sharp_plugin
             {
                 MetaElement mElement = new MetaElement();
                 mElement.name = (string)obj["name"];
-                mElement.value = (string)obj["value"];
+                mElement.value = obj.GetValue("value").ToString();
                 mElement.key = (string)obj["key"];
 
                 asset.meta.Add(mElement);


### PR DESCRIPTION
Metadata was not parsed correctly when it was an array and produced a crash at runtime...